### PR TITLE
fix: updating networking package repo to new repo

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "di-mobile-ios-networking",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/alphagov/di-mobile-ios-networking.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "e766a87733bd12029149b1be72586f64fc034ca8"
-      }
-    },
-    {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
@@ -88,6 +79,15 @@
       "state" : {
         "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
         "version" : "1.22.2"
+      }
+    },
+    {
+      "identity" : "mobile-ios-networking",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/govuk-one-login/mobile-ios-networking.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "8724c7ffcbc2546e3b1fa57f1021769e12b475ea"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             .upToNextMajor(from: "10.15.0")
         ),
         .package(
-            url: "https://github.com/alphagov/di-mobile-ios-networking.git",
+            url: "https://github.com/govuk-one-login/mobile-ios-networking.git",
             branch: "main"
         )
     ],
@@ -31,7 +31,7 @@ let package = Package(
                     dependencies: ["Logging"]),
         
         .target(name: "HTTPLogging",
-                dependencies: ["Logging", .product(name: "Networking", package: "di-mobile-ios-networking")],
+                dependencies: ["Logging", .product(name: "Networking", package: "mobile-ios-networking")],
                 exclude: ["README.md"],
                 swiftSettings: [
                     .define("DEBUG", .when(configuration: .debug))
@@ -39,7 +39,7 @@ let package = Package(
         .testTarget(name: "HTTPLoggingTests",
                     dependencies: [
                         "HTTPLogging",
-                        .product(name: "MockNetworking", package: "di-mobile-ios-networking")
+                        .product(name: "MockNetworking", package: "mobile-ios-networking")
                     ]),
         
         .target(name: "GAnalytics",


### PR DESCRIPTION
# Updating the package manifest for `Networking` package

This PR updates the manifest to point to the new repo for `Networking`. Currently the package points to the old repo location which causes package resolution errors when importing into an app that also imports `Networking` from the new location.

# Checklist

## Before raising your pull request:
~- [ ] Update the documentation to reflect your changes~
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?~
    ~- [ ] Checked dynamic type sizes are applied~
    ~- [ ] Checked VoiceOver can navigate your new code~
    ~- [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`