### PR TITLE
feat: add support for new GA schema by creating new LoggableScreenV2 which supports both screen name and class

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-networking.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "5f88a16f03698438eb00e23651f984bb23ff578a"
+        "revision" : "9cc300c9e4e966aaa4df232b388b574262ee4537",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-networking.git",
       "state" : {
-        "revision" : "9cc300c9e4e966aaa4df232b388b574262ee4537",
-        "version" : "1.0.0"
+        "revision" : "5f88a16f03698438eb00e23651f984bb23ff578a",
+        "version" : "2.0.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -87,7 +87,7 @@
       "location" : "https://github.com/govuk-one-login/mobile-ios-networking.git",
       "state" : {
         "branch" : "main",
-        "revision" : "8724c7ffcbc2546e3b1fa57f1021769e12b475ea"
+        "revision" : "5f88a16f03698438eb00e23651f984bb23ff578a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/govuk-one-login/mobile-ios-networking.git",
-            branch: "main"
+            .upToNextMajor(from: "1.0.0")
         )
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/govuk-one-login/mobile-ios-networking.git",
-            .upToNextMajor(from: "1.0.0")
+            .upToNextMajor(from: "2.0.0")
         )
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -51,6 +51,8 @@ let package = Package(
                 exclude: ["README.md"],
                 swiftSettings: [
                     .define("DEBUG", .when(configuration: .debug))
-                ])
+                ]),
+        .testTarget(name: "GAnalyticsTests",
+                    dependencies: ["GAnalytics"])
     ]
 )

--- a/Sources/GAnalytics/AnalyticsLogger.swift
+++ b/Sources/GAnalytics/AnalyticsLogger.swift
@@ -1,7 +1,7 @@
 import FirebaseAnalytics
 
 protocol AnalyticsLogger {
-    static func logEvent(_ name: String, parameters: [String : Any]?)
+    static func logEvent(_ name: String, parameters: [String: Any]?)
 }
 
 extension Analytics: AnalyticsLogger { }

--- a/Sources/GAnalytics/AnalyticsLogger.swift
+++ b/Sources/GAnalytics/AnalyticsLogger.swift
@@ -1,0 +1,7 @@
+import FirebaseAnalytics
+
+protocol AnalyticsLogger {
+    static func logEvent(_ name: String, parameters: [String : Any]?)
+}
+
+extension Analytics: AnalyticsLogger { }

--- a/Sources/GAnalytics/GAnalytics.swift
+++ b/Sources/GAnalytics/GAnalytics.swift
@@ -40,8 +40,6 @@ public class GAnalytics {
     }
     
     public convenience init() {
-        // this is empty because there are no properties to initialise but
-        // it is required to initialise this outside of the package
         self.init(analytics: Analytics.self)
     }
     

--- a/Sources/GAnalytics/GAnalytics.swift
+++ b/Sources/GAnalytics/GAnalytics.swift
@@ -10,7 +10,7 @@ import Logging
 public class GAnalytics {
     /// Additional parameters for the application
     public var additionalParameters = [String: Any]()
-    private let analytics: AnalyticsLogger.Type
+    let analytics: AnalyticsLogger.Type
     
     /// Initialises the Firebase instance when launching the app.
     public func configure() {
@@ -21,10 +21,7 @@ public class GAnalytics {
     
     /// Creates Notification Center Observer for user's analytics permissions for the app.
     private func bundleDataObserver() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(fetchSettingBundleData),
-                                               name: UserDefaults.didChangeNotification,
-                                               object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(fetchSettingBundleData), name: UserDefaults.didChangeNotification, object: nil)
     }
     
     /// Fetches permissions for analytics from User Defaults.

--- a/Sources/GAnalytics/GAnalytics.swift
+++ b/Sources/GAnalytics/GAnalytics.swift
@@ -68,7 +68,7 @@ extension GAnalytics: AnalyticsService {
     }
     
     public func trackScreen(_ screen: LoggableScreenV2,
-                            parameters params: [String : Any]) {
+                            parameters params: [String: Any]) {
         var parameters = mergeAdditionalParameters(params)
         
         parameters[AnalyticsParameterScreenClass] = screen.type.name
@@ -102,4 +102,3 @@ extension GAnalytics: AnalyticsService {
         Analytics.resetAnalyticsData()
     }
 }
-

--- a/Sources/GAnalytics/GAnalytics.swift
+++ b/Sources/GAnalytics/GAnalytics.swift
@@ -46,6 +46,17 @@ public class GAnalytics: AnalyticsService {
                            parameters: parameters)
     }
     
+    public func trackScreen(_ screen: LoggableScreenV2,
+                            parameters params: [String : Any]) {
+        var parameters = mergeAdditionalParameters(params)
+        
+        parameters[AnalyticsParameterScreenClass] = screen.type.name
+        parameters[AnalyticsParameterScreenName] = screen.name
+        
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: parameters)
+    }
+    
     /// Logs events accepting the event name and parameters in Firebase package.
     public func logEvent(_ event: LoggableEvent, parameters params: [String: Any]) {
         let parameters = mergeAdditionalParameters(params)

--- a/Sources/Logging/AnalyticsService.swift
+++ b/Sources/Logging/AnalyticsService.swift
@@ -6,8 +6,14 @@ import Foundation
 public protocol AnalyticsService: LoggingService {
     var additionalParameters: [String: Any] { get set }
     
+    @available(*, deprecated, renamed: "trackScreen", message: "Please use LoggableScreenV2")
     func trackScreen(_ screen: LoggableScreen)
+    
+    @available(*, deprecated, renamed: "trackScreen", message: "Please use LoggableScreenV2")
     func trackScreen(_ screen: LoggableScreen, parameters: [String: Any])
+    
+    func trackScreen(_ screen: LoggableScreenV2)
+    func trackScreen(_ screen: LoggableScreenV2, parameters: [String: Any])
     
     func logCrash(_ crash: NSError)
     func logCrash(_ crash: Error)
@@ -19,6 +25,10 @@ public protocol AnalyticsService: LoggingService {
 extension AnalyticsService {
     /// Protocol method for screen tracking, calling the conforming type's method for adding screen tracking parameters.
     public func trackScreen(_ screen: LoggableScreen) {
+        trackScreen(screen, parameters: [:])
+    }
+    
+    public func trackScreen(_ screen: LoggableScreenV2) {
         trackScreen(screen, parameters: [:])
     }
     

--- a/Sources/Logging/AnalyticsService.swift
+++ b/Sources/Logging/AnalyticsService.swift
@@ -21,19 +21,3 @@ public protocol AnalyticsService: LoggingService {
     func grantAnalyticsPermission()
     func denyAnalyticsPermission()
 }
-
-extension AnalyticsService {
-    /// Protocol method for screen tracking, calling the conforming type's method for adding screen tracking parameters.
-    public func trackScreen(_ screen: LoggableScreen) {
-        trackScreen(screen, parameters: [:])
-    }
-    
-    public func trackScreen(_ screen: LoggableScreenV2) {
-        trackScreen(screen, parameters: [:])
-    }
-    
-    /// Protocol method for crash logging, calling the conforming type's method for passing errors as `NSError`s.
-    public func logCrash(_ crash: Error) {
-        logCrash(crash as NSError)
-    }
-}

--- a/Sources/Logging/AnalyticsService.swift
+++ b/Sources/Logging/AnalyticsService.swift
@@ -11,7 +11,9 @@ public protocol AnalyticsService: LoggingService {
     
     @available(*, deprecated, renamed: "trackScreen", message: "Please use LoggableScreenV2")
     func trackScreen(_ screen: LoggableScreen, parameters: [String: Any])
-        
+    
+    func trackScreen(_ screen: LoggableScreenV2, parameters: [String: Any])
+    
     func logCrash(_ crash: NSError)
     func logCrash(_ crash: Error)
     

--- a/Sources/Logging/AnalyticsService.swift
+++ b/Sources/Logging/AnalyticsService.swift
@@ -11,13 +11,22 @@ public protocol AnalyticsService: LoggingService {
     
     @available(*, deprecated, renamed: "trackScreen", message: "Please use LoggableScreenV2")
     func trackScreen(_ screen: LoggableScreen, parameters: [String: Any])
-    
-    func trackScreen(_ screen: LoggableScreenV2)
-    func trackScreen(_ screen: LoggableScreenV2, parameters: [String: Any])
-    
+        
     func logCrash(_ crash: NSError)
     func logCrash(_ crash: Error)
     
     func grantAnalyticsPermission()
     func denyAnalyticsPermission()
+}
+
+extension AnalyticsService {
+    /// Protocol method for screen tracking, calling the conforming type's method for adding screen tracking parameters.
+    public func trackScreen(_ screen: LoggableScreen) {
+        trackScreen(screen, parameters: [:])
+    }
+    
+    /// Protocol method for crash logging, calling the conforming type's method for passing errors as `NSError`s.
+    public func logCrash(_ crash: Error) {
+        logCrash(crash as NSError)
+    }
 }

--- a/Sources/Logging/LoggableScreen.swift
+++ b/Sources/Logging/LoggableScreen.swift
@@ -1,15 +1,1 @@
-/// LoggingScreen
-///
-/// A protocol for Types to hold a value for screen tracking.
-public protocol LoggableScreen {
-    var name: String { get }
-}
-
-extension LoggableScreen where Self: RawRepresentable,
-                                Self.RawValue == String {
-    
-    /// Protocol method returning the string value from a Type's `name` property which conforms to this protocol.
-    public var name: String {
-        rawValue
-    }
-}
+public typealias LoggableScreen = ScreenType

--- a/Sources/Logging/LoggableScreenV2.swift
+++ b/Sources/Logging/LoggableScreenV2.swift
@@ -1,0 +1,4 @@
+public protocol LoggableScreenV2 {
+    var name: String { get }
+    var type: ScreenType { get }
+}

--- a/Sources/Logging/ScreenType.swift
+++ b/Sources/Logging/ScreenType.swift
@@ -1,0 +1,15 @@
+/// ScreenType
+///
+/// A protocol for types to hold a value for screen tracking.
+public protocol ScreenType {
+    var name: String { get }
+}
+
+extension ScreenType where Self: RawRepresentable,
+                                Self.RawValue == String {
+    
+    /// Protocol method returning the string value from a Type's `name` property which conforms to this protocol.
+    public var name: String {
+        rawValue
+    }
+}

--- a/Tests/GAnalyticsTests/GAnalyticsTests.swift
+++ b/Tests/GAnalyticsTests/GAnalyticsTests.swift
@@ -15,6 +15,7 @@ final class GAnalyticsTests: XCTestCase {
     
     override func tearDown() {
         sut = nil
+        logger.reset()
         logger = nil
         super.tearDown()
     }

--- a/Tests/GAnalyticsTests/GAnalyticsTests.swift
+++ b/Tests/GAnalyticsTests/GAnalyticsTests.swift
@@ -58,4 +58,17 @@ extension GAnalyticsTests {
             ])]
         )
     }
+    
+    func testTrackEvent() {
+        enum MyAppEvents: String, LoggableEvent {
+            case buttonPress
+        }
+        
+        sut.logEvent(MyAppEvents.buttonPress)
+        
+        XCTAssertEqual(
+            logger.events,
+            [.init(name: "buttonPress", parameters: [:])]
+        )
+    }
 }

--- a/Tests/GAnalyticsTests/GAnalyticsTests.swift
+++ b/Tests/GAnalyticsTests/GAnalyticsTests.swift
@@ -26,15 +26,15 @@ extension GAnalyticsTests {
     }
     
     func testTrackScreen() {
-        sut.trackScreen(TestScreen.welcome, 
-                        parameters: ["additional_parameter" : "testing"])
+        sut.trackScreen(TestScreen.welcome,
+                        parameters: ["additional_parameter": "testing"])
         
         XCTAssertEqual(
-            logger.events, 
+            logger.events,
             [.init(name: "screen_view", parameters: [
-                "screen_class" : "WELCOME_SCREEN",
-                "screen_name" : "WELCOME_SCREEN",
-                "additional_parameter" : "testing"
+                "screen_class": "WELCOME_SCREEN",
+                "screen_name": "WELCOME_SCREEN",
+                "additional_parameter": "testing"
             ])]
         )
     }
@@ -46,14 +46,14 @@ extension GAnalyticsTests {
         }
         
         sut.trackScreen(TestScreenV2(),
-                        parameters: ["additional_parameter" : "testing"])
+                        parameters: ["additional_parameter": "testing"])
         
         XCTAssertEqual(
             logger.events,
             [.init(name: "screen_view", parameters: [
-                "screen_class" : "WELCOME_SCREEN",
-                "screen_name" : "Welcome to GOV.UK One Login",
-                "additional_parameter" : "testing"
+                "screen_class": "WELCOME_SCREEN",
+                "screen_name": "Welcome to GOV.UK One Login",
+                "additional_parameter": "testing"
             ])]
         )
     }

--- a/Tests/GAnalyticsTests/GAnalyticsTests.swift
+++ b/Tests/GAnalyticsTests/GAnalyticsTests.swift
@@ -1,0 +1,60 @@
+@testable import GAnalytics
+import Logging
+import XCTest
+
+final class GAnalyticsTests: XCTestCase {
+    private var sut: GAnalytics!
+    private var logger: MockAnalyticsLogger.Type!
+    
+    override func setUp() {
+        super.setUp()
+        
+        logger = MockAnalyticsLogger.self
+        sut = GAnalytics(analytics: logger)
+    }
+    
+    override func tearDown() {
+        sut = nil
+        logger = nil
+        super.tearDown()
+    }
+}
+
+extension GAnalyticsTests {
+    enum TestScreen: String, LoggableScreen {
+        case welcome = "WELCOME_SCREEN"
+    }
+    
+    func testTrackScreen() {
+        sut.trackScreen(TestScreen.welcome, 
+                        parameters: ["additional_parameter" : "testing"])
+        
+        XCTAssertEqual(
+            logger.events, 
+            [.init(name: "screen_view", parameters: [
+                "screen_class" : "WELCOME_SCREEN",
+                "screen_name" : "WELCOME_SCREEN",
+                "additional_parameter" : "testing"
+            ])]
+        )
+    }
+    
+    func testTrackScreenV2() {
+        struct TestScreenV2: LoggableScreenV2 {
+            let name: String = "Welcome to GOV.UK One Login"
+            let type: ScreenType = TestScreen.welcome
+        }
+        
+        sut.trackScreen(TestScreenV2(),
+                        parameters: ["additional_parameter" : "testing"])
+        
+        XCTAssertEqual(
+            logger.events,
+            [.init(name: "screen_view", parameters: [
+                "screen_class" : "WELCOME_SCREEN",
+                "screen_name" : "Welcome to GOV.UK One Login",
+                "additional_parameter" : "testing"
+            ])]
+        )
+    }
+}

--- a/Tests/GAnalyticsTests/Mocks/MockAnalyticsLogger.swift
+++ b/Tests/GAnalyticsTests/Mocks/MockAnalyticsLogger.swift
@@ -8,7 +8,7 @@ final class MockAnalyticsLogger: AnalyticsLogger {
     
     private(set) static var events: [Event] = []
     
-    static func logEvent(_ name: String, parameters: [String : Any]?) {
+    static func logEvent(_ name: String, parameters: [String: Any]?) {
         guard let parameters = parameters as? [String: String] else {
             preconditionFailure("Expected parameters dictionary to contain String values only.")
         }

--- a/Tests/GAnalyticsTests/Mocks/MockAnalyticsLogger.swift
+++ b/Tests/GAnalyticsTests/Mocks/MockAnalyticsLogger.swift
@@ -14,4 +14,8 @@ final class MockAnalyticsLogger: AnalyticsLogger {
         }
         events.append(Event(name: name, parameters: parameters))
     }
+    
+    static func reset() {
+        events = []
+    }
 }

--- a/Tests/GAnalyticsTests/Mocks/MockAnalyticsLogger.swift
+++ b/Tests/GAnalyticsTests/Mocks/MockAnalyticsLogger.swift
@@ -1,0 +1,17 @@
+@testable import GAnalytics
+
+final class MockAnalyticsLogger: AnalyticsLogger {
+    struct Event: Equatable {
+        let name: String
+        let parameters: [String: String]
+    }
+    
+    private(set) static var events: [Event] = []
+    
+    static func logEvent(_ name: String, parameters: [String : Any]?) {
+        guard let parameters = parameters as? [String: String] else {
+            preconditionFailure("Expected parameters dictionary to contain String values only.")
+        }
+        events.append(Event(name: name, parameters: parameters))
+    }
+}

--- a/Tests/LoggingTests/LoggingServiceTests.swift
+++ b/Tests/LoggingTests/LoggingServiceTests.swift
@@ -1,36 +1,6 @@
 @testable import Logging
 import XCTest
 
-class MockLoggingService: AnalyticsService {    
-    var additionalParameters: [String: Any] = [:]
-    
-    var screensVisited: [String] = []
-    var screenParamsLogged: [String: Any] = [:]
-    var eventsLogged: [LoggableEvent] = []
-    
-    func logCrash(_ crash: NSError) { }
-    func grantAnalyticsPermission() { }
-    func denyAnalyticsPermission() { }
-    
-    func trackScreen(_ screen: LoggableScreen,
-                     parameters: [String: Any]) {
-        screensVisited.append(screen.name)
-        screenParamsLogged = parameters
-    }
-    
-    func trackScreen(_ screen: LoggableScreenV2,
-                     parameters: [String : Any]) {
-        
-        screensVisited.append(screen.name)
-        screenParamsLogged = parameters
-    }
-    
-    func logEvent(_ event: LoggableEvent,
-                  parameters: [String: Any]) {
-        eventsLogged.append(event)
-    }
-}
-
 final class LoggingServiceTests: XCTestCase {
     func testAnalyticsService() {
         let service = MockLoggingService()
@@ -45,5 +15,38 @@ final class LoggingServiceTests: XCTestCase {
         
         service.trackScreen(MockAnalyticsScreen.drivingLicenceFrontInstructions)
         XCTAssertEqual(service.screensVisited.count, 2)
+    }
+    
+    enum TestScreen: String, LoggableScreen {
+        case welcome = "WELCOME_SCREEN"
+    }
+    
+    func testTrackScreen() {
+        let service = MockLoggingService()
+        service.trackScreen(TestScreen.welcome, parameters: [:])
+        
+        XCTAssertEqual(
+            service.screensVisited,
+            [
+                MockScreen(name: "WELCOME_SCREEN", class: "WELCOME_SCREEN")
+            ]
+        )
+    }
+    
+    func testTrackScreenV2() {
+        struct TestScreenV2: LoggableScreenV2 {
+            let name: String = "Welcome to GOV.UK One Login"
+            let type: ScreenType = TestScreen.welcome
+        }
+        
+        let service = MockLoggingService()
+        service.trackScreen(TestScreenV2(), parameters: [:])
+        
+        XCTAssertEqual(
+            service.screensVisited,
+            [
+                MockScreen(name: "Welcome to GOV.UK One Login", class: "WELCOME_SCREEN")
+            ]
+        )
     }
 }

--- a/Tests/LoggingTests/LoggingServiceTests.swift
+++ b/Tests/LoggingTests/LoggingServiceTests.swift
@@ -1,7 +1,7 @@
 @testable import Logging
 import XCTest
 
-class MockLoggingService: AnalyticsService {
+class MockLoggingService: AnalyticsService {    
     var additionalParameters: [String: Any] = [:]
     
     var screensVisited: [String] = []
@@ -14,6 +14,13 @@ class MockLoggingService: AnalyticsService {
     
     func trackScreen(_ screen: LoggableScreen,
                      parameters: [String: Any]) {
+        screensVisited.append(screen.name)
+        screenParamsLogged = parameters
+    }
+    
+    func trackScreen(_ screen: LoggableScreenV2,
+                     parameters: [String : Any]) {
+        
         screensVisited.append(screen.name)
         screenParamsLogged = parameters
     }

--- a/Tests/LoggingTests/Mocks/MockLoggingService.swift
+++ b/Tests/LoggingTests/Mocks/MockLoggingService.swift
@@ -24,7 +24,7 @@ final class MockLoggingService: AnalyticsService {
     }
     
     func trackScreen(_ screen: LoggableScreenV2,
-                     parameters: [String : Any]) {
+                     parameters: [String: Any]) {
         screensVisited.append(
             MockScreen(name: screen.name, class: screen.type.name)
         )

--- a/Tests/LoggingTests/Mocks/MockLoggingService.swift
+++ b/Tests/LoggingTests/Mocks/MockLoggingService.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Logging
+
+struct MockScreen: Equatable {
+    let name: String
+    let `class`: String
+}
+
+final class MockLoggingService: AnalyticsService {
+    var additionalParameters: [String: Any] = [:]
+    
+    var screensVisited: [MockScreen] = []
+    var screenParamsLogged: [String: Any] = [:]
+    var eventsLogged: [LoggableEvent] = []
+    
+    func logCrash(_ crash: NSError) { }
+    func grantAnalyticsPermission() { }
+    func denyAnalyticsPermission() { }
+    
+    func trackScreen(_ screen: LoggableScreen,
+                     parameters: [String: Any]) {
+        screensVisited.append(MockScreen(name: screen.name, class: screen.name))
+        screenParamsLogged = parameters
+    }
+    
+    func trackScreen(_ screen: LoggableScreenV2,
+                     parameters: [String : Any]) {
+        screensVisited.append(
+            MockScreen(name: screen.name, class: screen.type.name)
+        )
+        screenParamsLogged = parameters
+    }
+    
+    func logEvent(_ event: LoggableEvent,
+                  parameters: [String: Any]) {
+        eventsLogged.append(event)
+    }
+}


### PR DESCRIPTION
# DCMAW-7991: New GA4 Schema implementation

Implemented new GA4 schema support which includes sending both screen name and class to Firebase.

This change uses a new `LoggableScreenV2` type with `name` and `type`, which will be mapped to Firebase's [AnalyticsParameterScreenName](https://firebase.google.com/docs/reference/swift/firebaseanalytics/api/reference/Constants#/c:FIRParameterNames.h@kFIRParameterScreenName) and [AnalyticsParameterScreenClass](https://firebase.google.com/docs/reference/swift/firebaseanalytics/api/reference/Constants#/c:FIRParameterNames.h@kFIRParameterScreenClass) respectively.

```swift
protocol LoggableScreenV2 {
    var name: String { get }
    var type: ScreenType { get }
}
```

To allow for a gradual migration from one schema to another, I have marked the old trackScreen methods as deprecated, but not removed them.

This change is also related to the similar change made in the analytics schema in ios-common:
https://github.com/govuk-one-login/mobile-ios-common/pull/51

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
