### PR TITLE
fix: reset analytics permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,7 +45,7 @@ jobs:
           xcodebuild -scheme Logging-Package test \
             -destination "platform=iOS Simulator,name=iPhone 15,OS=latest" \
             -enableCodeCoverage YES \
-            -resultBundlePath result.xcresult
+            -resultBundlePath result.xcresult | xcbeautify
             
       - name: Run SonarCloud Scanning
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,14 +36,20 @@ jobs:
         with:
           ACTION_TYPE: 'Validate'
 
+      - name: Xcode select
+        run: |
+          sudo xcode-select -s /Applications/Xcode_15.2.app
+
       - name: Build and Test
         run: |
-          xcodebuild -scheme Logging-Package test -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
-            -enableCodeCoverage YES -resultBundlePath result.xcresult
+          xcodebuild -scheme Logging-Package test \
+            -destination "platform=iOS Simulator,name=iPhone 15,OS=latest" \
+            -enableCodeCoverage YES \
+            -resultBundlePath result.xcresult
             
       - name: Run SonarCloud Scanning
         run: |
-          bash xccov-to-sonarqube-generic.sh result.xcresult/ >Coverage.xml
+          bash xccov-to-sonarqube-generic.sh result.xcresult > sonarqube-generic-coverage.xml
 
           brew install sonar-scanner
 
@@ -51,7 +57,7 @@ jobs:
 
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
-            -Dsonar.coverageReportPaths="Coverage.xml" \
+            -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml" \
             -Dsonar.pullrequest.key=$pull_number \
             -Dsonar.pullrequest.branch=${{github.head_ref}} \
             -Dsonar.pullrequest.base=${{github.base_ref}}

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-
 jobs:
   build:
     name: Run Quality Report
@@ -22,20 +21,26 @@ jobs:
         with:
           lfs: 'true'
 
+      - name: Xcode select
+        run: |
+          sudo xcode-select -s /Applications/Xcode_15.2.app
+
       - name: Build and Test
         run: |
-          xcodebuild -scheme Logging-Package test -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
-            -enableCodeCoverage YES -resultBundlePath result.xcresult
+          xcodebuild -scheme Logging-Package test \
+            -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
+            -enableCodeCoverage YES \
+            -resultBundlePath result.xcresult
             
       - name: Run SonarCloud Scanning
         run: |
-          bash xccov-to-sonarqube-generic.sh result.xcresult/ >Coverage.xml
+          bash xccov-to-sonarqube-generic.sh result.xcresult > sonarqube-generic-coverage.xml
 
           brew install sonar-scanner
 
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
-            -Dsonar.coverageReportPaths="Coverage.xml"
+            -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # pin@v4
         with:
           lfs: 'true'
+          fetch-depth: 0
 
       - name: Xcode select
         run: |
@@ -28,9 +29,9 @@ jobs:
       - name: Build and Test
         run: |
           xcodebuild -scheme Logging-Package test \
-            -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
+            -destination "platform=iOS Simulator,name=iPhone 15,OS=latest" \
             -enableCodeCoverage YES \
-            -resultBundlePath result.xcresult
+            -resultBundlePath result.xcresult | xcbeautify
             
       - name: Run SonarCloud Scanning
         run: |

--- a/Sources/Logging/Privacy/AnalyticsPreferenceStore.swift
+++ b/Sources/Logging/Privacy/AnalyticsPreferenceStore.swift
@@ -27,9 +27,13 @@ public final class UserDefaultsPreferenceStore: AnalyticsPreferenceStore {
             return value(for: .hasAcceptedAnalytics)
         }
         set {
-            guard let newValue else { return }
-            defaults.set(true, forKey: DefaultsKey.hasAskedForAnalyticsPermissions.rawValue)
-            defaults.set(newValue, forKey: DefaultsKey.hasAcceptedAnalytics.rawValue)
+            if let newValue {
+                defaults.set(true, forKey: DefaultsKey.hasAskedForAnalyticsPermissions.rawValue)
+                defaults.set(newValue, forKey: DefaultsKey.hasAcceptedAnalytics.rawValue)
+            } else {
+                defaults.set(false, forKey: DefaultsKey.hasAskedForAnalyticsPermissions.rawValue)
+                defaults.set(false, forKey: DefaultsKey.hasAcceptedAnalytics.rawValue)
+            }
         }
     }
     

--- a/Tests/LoggingTests/UserDefaultsPreferenceStoreTests.swift
+++ b/Tests/LoggingTests/UserDefaultsPreferenceStoreTests.swift
@@ -40,8 +40,8 @@ extension UserDefaultsPreferenceStoreTests {
     func testClearAnalyticsPreference() {
         sut.hasAcceptedAnalytics = nil
         
-        XCTAssertNil(defaults.object(forKey: "hasAskedForAnalyticsPermissions"))
-        XCTAssertNil(defaults.object(forKey: "hasAcceptedAnalytics"))
+        XCTAssertFalse(defaults.bool(forKey: "hasAskedForAnalyticsPermissions"))
+        XCTAssertFalse(defaults.bool(forKey: "hasAcceptedAnalytics"))
     }
     
     func testAcceptAnalytics() {


### PR DESCRIPTION
# DCMAW-9299: iOS | Mobile Platform | Resetting analytics permissions

If we would like to reset analytics permissions for a user, the changes in this PR for the setter in `hasAcceptedAnalytics` when the property is set to `nil` will allow us to create the correct conditions for the getter.
In this scenario where we are testing to see if they have been asked before, in order to potentially ask again, setting `hasAcceptedAnalytics` to nil will return nil as `UserDefaults.bool(forKey:)` will return a nil or false as a false Bool value.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
