### PR TITLE
chore!: bumps networking dependency to latest major version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-networking.git",
       "state" : {
-        "revision" : "170ffc77a30c4ca8e36f273191c11620c3b2278d",
-        "version" : "2.1.0"
+        "revision" : "7ea8b9091042545403eb1db2ad2cc60e9ce17191",
+        "version" : "3.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/govuk-one-login/mobile-ios-networking.git",
-            .upToNextMajor(from: "2.0.0")
+            .upToNextMajor(from: "3.0.0")
         )
     ],
     targets: [

--- a/Tests/HTTPLoggingTests/HTTPLoggingTests.swift
+++ b/Tests/HTTPLoggingTests/HTTPLoggingTests.swift
@@ -69,13 +69,15 @@ extension HTTPLoggingTests {
         XCTAssertEqual(request.url?.scheme, "https")
         XCTAssertEqual(request.url?.host, "example.com")
         XCTAssertEqual(request.url?.path, "/dev")
-        
-        let httpBody = try XCTUnwrap(request.bodySteamAsJSON() as? [String: Any])
-        
-        let ID = try XCTUnwrap(httpBody["sessionId"] as? String)
+
+        let httpData = try XCTUnwrap(request.httpBodyData())
+        let decoder = JSONDecoder()
+        let httpBody = try decoder.decode([String: String].self, from: httpData)
+
+        let ID = try XCTUnwrap(httpBody["sessionId"])
         XCTAssertEqual(sessionID, ID)
         
-        let eventName = try XCTUnwrap(httpBody["eventName"] as? String)
+        let eventName = try XCTUnwrap(httpBody["eventName"])
         XCTAssertEqual(MockEvent.testEvent.rawValue, eventName)
     }
     
@@ -101,13 +103,15 @@ extension HTTPLoggingTests {
         XCTAssertEqual(request.url?.scheme, "https")
         XCTAssertEqual(request.url?.host, "example.com")
         XCTAssertEqual(request.url?.path, "/dev")
-        
-        let httpBody = try XCTUnwrap(request.bodySteamAsJSON() as? [String: Any])
-        
-        let ID = try XCTUnwrap(httpBody["sessionId"] as? String)
+
+        let httpData = try XCTUnwrap(request.httpBodyData())
+        let decoder = JSONDecoder()
+        let httpBody = try decoder.decode([String: String].self, from: httpData)
+
+        let ID = try XCTUnwrap(httpBody["sessionId"])
         XCTAssertEqual(sessionID, ID)
         
-        let eventName = try XCTUnwrap(httpBody["eventName"] as? String)
+        let eventName = try XCTUnwrap(httpBody["eventName"])
         XCTAssertEqual(MockEvent.testEvent.rawValue, eventName)
     }
 }


### PR DESCRIPTION
# chore!: bumps networking dependency to latest major version

Requirement for [DCMAW-10102](https://govukverify.atlassian.net/browse/DCMAW-10102)

Increments Logging to use the new major release of the Networking package:
https://github.com/govuk-one-login/mobile-ios-networking/pull/26

Consumers of this Logging package cannot update to Networking@3.0.0 until this package is updated.

There are no breaking changes in the Logging usage of this package.

[DCMAW-10102]: https://govukverify.atlassian.net/browse/DCMAW-10102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

**! This is a breaking change as consumers will be required to update to Networking@3.0.0 alongside this update.**