### PR TITLE
refactor!: detach LoggableScreenV2 from screen type protocol

### DIFF
--- a/Sources/GAnalytics/GAnalytics.swift
+++ b/Sources/GAnalytics/GAnalytics.swift
@@ -88,11 +88,11 @@ extension GAnalytics: AnalyticsService {
                            parameters: parameters)
     }
     
-    public func trackScreen(_ screen: LoggableScreenV2,
+    public func trackScreen(_ screen: any LoggableScreenV2,
                             parameters params: [String: Any]) {
         var parameters = mergeAdditionalParameters(params)
         
-        parameters[AnalyticsParameterScreenClass] = screen.type.name
+        parameters[AnalyticsParameterScreenClass] = screen.type.description
         parameters[AnalyticsParameterScreenName] = screen.name
         
         analytics.logEvent(AnalyticsEventScreenView,

--- a/Sources/GDSAnalytics/Screens/ScreenType.swift
+++ b/Sources/GDSAnalytics/Screens/ScreenType.swift
@@ -1,8 +1,14 @@
 @available(*, deprecated, renamed: "ScreenType")
 public typealias NamedScreen = ScreenType
 
-public protocol ScreenType {
+public protocol ScreenType: CustomStringConvertible {
     var name: String { get }
+}
+
+extension ScreenType {
+    public var description: String {
+        name
+    }
 }
 
 extension ScreenType where Self: RawRepresentable,

--- a/Sources/Logging/AnalyticsService.swift
+++ b/Sources/Logging/AnalyticsService.swift
@@ -13,7 +13,7 @@ public protocol AnalyticsService: LoggingService {
     @available(*, deprecated, renamed: "trackScreen", message: "Please use LoggableScreenV2")
     func trackScreen(_ screen: LoggableScreen, parameters: [String: Any])
     
-    func trackScreen(_ screen: LoggableScreenV2, parameters: [String: Any])
+    func trackScreen(_ screen: any LoggableScreenV2, parameters: [String: Any])
     
     func logCrash(_ crash: NSError)
     func logCrash(_ crash: Error)

--- a/Sources/Logging/LoggableScreenV2.swift
+++ b/Sources/Logging/LoggableScreenV2.swift
@@ -1,4 +1,6 @@
 public protocol LoggableScreenV2 {
+    associatedtype ScreenType: CustomStringConvertible
+
     var name: String { get }
     var type: ScreenType { get }
 }

--- a/Tests/GAnalyticsTests/GAnalyticsTests.swift
+++ b/Tests/GAnalyticsTests/GAnalyticsTests.swift
@@ -156,10 +156,11 @@ extension GAnalyticsTests {
 
 // MARK: - Logging Tests
 extension GAnalyticsTests {
-    enum TestScreen: String, LoggableScreen {
+    enum TestScreen: String, LoggableScreen, CustomStringConvertible {
         case welcome = "WELCOME_SCREEN"
         
         var name: String { rawValue }
+        var description: String { rawValue }
     }
     
     func testTrackScreen() {
@@ -198,7 +199,7 @@ extension GAnalyticsTests {
     func testTrackScreenV2() {
         struct TestScreenV2: LoggableScreenV2 {
             let name: String = "Welcome to GOV.UK One Login"
-            let type: ScreenType = TestScreen.welcome
+            let type: TestScreen = .welcome
         }
         
         sut.trackScreen(TestScreenV2(),

--- a/Tests/GDSAnalyticsTests/Screens/ScreenTypeTests.swift
+++ b/Tests/GDSAnalyticsTests/Screens/ScreenTypeTests.swift
@@ -3,8 +3,14 @@ import XCTest
 
 final class ScreenTypeTests: XCTestCase {
     func testNameConformance() {
-        XCTAssertEqual(MockScreenType.drivingLicenceFrontInstructions.name,
-                       "drivingLicenceFrontInstructions")
+        XCTAssertEqual(
+            MockScreenType.drivingLicenceFrontInstructions.name,
+            "drivingLicenceFrontInstructions"
+        )
+        XCTAssertEqual(
+            MockScreenType.drivingLicenceFrontInstructions.description,
+            "drivingLicenceFrontInstructions"
+        )
     }
 }
 

--- a/Tests/LoggingTests/LoggingServiceTests.swift
+++ b/Tests/LoggingTests/LoggingServiceTests.swift
@@ -17,10 +17,11 @@ final class LoggingServiceTests: XCTestCase {
         XCTAssertEqual(service.screensVisited.count, 2)
     }
     
-    enum TestScreen: String, LoggableScreen {
+    enum TestScreen: String, LoggableScreen, CustomStringConvertible {
         case welcome = "WELCOME_SCREEN"
         
         var name: String { rawValue }
+        var description: String { rawValue }
     }
     
     func testTrackScreen() {
@@ -38,7 +39,7 @@ final class LoggingServiceTests: XCTestCase {
     func testTrackScreenV2() {
         struct TestScreenV2: LoggableScreenV2 {
             let name: String = "Welcome to GOV.UK One Login"
-            let type: ScreenType = TestScreen.welcome
+            let type: TestScreen = .welcome
         }
         
         let service = MockLoggingService()

--- a/Tests/LoggingTests/Mocks/MockLoggingService.swift
+++ b/Tests/LoggingTests/Mocks/MockLoggingService.swift
@@ -23,16 +23,14 @@ final class MockLoggingService: AnalyticsService {
         self
     }
     
-    func trackScreen(_ screen: LoggableScreen,
-                     parameters: [String: Any]) {
+    func trackScreen(_ screen: any LoggableScreen, parameters: [String: Any]) {
         screensVisited.append(MockScreen(name: screen.name, class: screen.name))
         screenParamsLogged = parameters
     }
     
-    func trackScreen(_ screen: LoggableScreenV2,
-                     parameters: [String: Any]) {
+    func trackScreen(_ screen: any LoggableScreenV2, parameters: [String: Any]) {
         screensVisited.append(
-            MockScreen(name: screen.name, class: screen.type.name)
+            MockScreen(name: screen.name, class: screen.type.description)
         )
         screenParamsLogged = parameters
     }


### PR DESCRIPTION
# refactor!: detach LoggableScreenV2 from screen type protocol

Use Swift's in-built `CustomStringConvertible` type to represent screen type in `LoggableScreenV2`. This means that SDK targets no longer need to import `Logging` as `Logging.ScreenType` is no longer needed.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Reviewed your own code to ensure you are following the style guidelines

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
