### PR TITLE
fix: ensure error screen title is correctly formatted

### DIFF
--- a/Sources/GDSAnalytics/Screens/ErrorScreenView.swift
+++ b/Sources/GDSAnalytics/Screens/ErrorScreenView.swift
@@ -30,7 +30,7 @@ public struct ErrorScreenView<Screen: ScreenType>: ScreenViewProtocol, LoggableE
                 hash: String? = nil,
                 bundle: Bundle = .main) {
         self.screen = screen
-        self.title = titleKey.englishString(bundle: bundle)
+        self.title = titleKey.englishString(bundle: bundle).formattedAsParameter
         self.id = id
         self.reason = reason
         self.endpoint = endpoint
@@ -46,7 +46,7 @@ public struct ErrorScreenView<Screen: ScreenType>: ScreenViewProtocol, LoggableE
        
         self.id = id
         self.screen = screen
-        title = titleKey.englishString(bundle: bundle)
+        title = titleKey.englishString(bundle: bundle).formattedAsParameter
         reason = error.reason
         endpoint = error.endpoint
         statusCode = error.statusCode

--- a/Tests/GDSAnalyticsTests/Screens/ErrorScreenViewTests.swift
+++ b/Tests/GDSAnalyticsTests/Screens/ErrorScreenViewTests.swift
@@ -7,7 +7,7 @@ final class ErrorScreenViewTests: XCTestCase {
                                    titleKey: "Something went wrong")
         
         XCTAssertEqual(view.screen, MockScreen.error)
-        XCTAssertEqual(view.title, "Something went wrong")
+        XCTAssertEqual(view.title, "something went wrong")
     }
     
     func testEmptyParametersAreRemoved() {
@@ -36,6 +36,8 @@ final class ErrorScreenViewTests: XCTestCase {
                                    screen: MockScreen.error,
                                    titleKey: "Something went wrong",
                                    error: MockError())
+        
+        XCTAssertEqual(view.title, "something went wrong")
         XCTAssertEqual(view.parameters, [
             "title": "something went wrong",
             "screen_id": uuid,


### PR DESCRIPTION
# fix: ensure error screen title is correctly formatted

This fixes an issue which meant that error screen titles were logged to GA4 formatted incorrectly (not lowercase or truncated).

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
