### PR TITLE
ci: moving to mac catalyst on the CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build and Test
         run: |
           set -o pipefail && xcodebuild -scheme Logging-Package test \
-            -destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.2" \
+            -destination "platform=macOS,arch=arm64,variant=Mac Catalyst" \
             -enableCodeCoverage YES \
             -resultBundlePath result.xcresult | xcbeautify
             

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build and Test
         run: |
           set -o pipefail && xcodebuild -scheme Logging-Package test \
-            -destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.2" \
+            -destination "platform=macOS,arch=arm64,variant=Mac Catalyst" \
             -enableCodeCoverage YES \
             -resultBundlePath result.xcresult | xcbeautify
             


### PR DESCRIPTION
# ci: moving to mac catalyst on the CI

Improving build and test times by having the workflow run on mac catalyst where no iOS simulator needs to be booted

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
~- [ ] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
