### PR TITLE
feat: adding `is_error` parameter to screen view events

### DIFF
--- a/Sources/GDSAnalytics/Screens/ErrorScreenView.swift
+++ b/Sources/GDSAnalytics/Screens/ErrorScreenView.swift
@@ -15,7 +15,8 @@ public struct ErrorScreenView<Screen: ScreenType>: ScreenViewProtocol, LoggableE
             ScreenParameter.reason.rawValue: reason,
             ScreenParameter.endpoint.rawValue: endpoint,
             ScreenParameter.hash.rawValue: hash,
-            ScreenParameter.status.rawValue: statusCode
+            ScreenParameter.status.rawValue: statusCode,
+            ScreenParameter.isError.rawValue: "true"
         ]
         .compactMapValues(\.?.formattedAsParameter)
     }

--- a/Sources/GDSAnalytics/Screens/ScreenParameter.swift
+++ b/Sources/GDSAnalytics/Screens/ScreenParameter.swift
@@ -4,4 +4,5 @@ public enum ScreenParameter: String {
     case status
     case hash
     case id = "screen_id"
+    case isError = "is_error"
 }

--- a/Sources/GDSAnalytics/Screens/ScreenView.swift
+++ b/Sources/GDSAnalytics/Screens/ScreenView.swift
@@ -15,7 +15,8 @@ public struct ScreenView<Screen: ScreenType>: ScreenViewProtocol {
     
     public var parameters: [String: String] {
         [
-            ScreenParameter.id.rawValue: id
+            ScreenParameter.id.rawValue: id,
+            ScreenParameter.isError.rawValue: "false"
         ].compactMapValues(\.?.formattedAsParameter)
     }
     

--- a/Tests/GDSAnalyticsTests/Screens/ErrorScreenViewTests.swift
+++ b/Tests/GDSAnalyticsTests/Screens/ErrorScreenViewTests.swift
@@ -12,14 +12,18 @@ final class ErrorScreenViewTests: XCTestCase {
     
     func testEmptyParametersAreRemoved() {
         let uuid = UUID().uuidString.lowercased()
-
+        
         let view = ErrorScreenView(id: uuid,
                                    screen: MockScreen.error,
                                    titleKey: "Something went wrong")
         
-        XCTAssertEqual(view.parameters, [
-            "screen_id": uuid
-        ])
+        XCTAssertEqual(
+            view.parameters,
+            [
+                "screen_id": uuid,
+                "is_error": "true"
+            ]
+        )
     }
     
     struct MockError: LoggableError {
@@ -31,38 +35,50 @@ final class ErrorScreenViewTests: XCTestCase {
     
     func testParametersForError() {
         let uuid = UUID().uuidString.lowercased()
-        let view = ErrorScreenView(id: uuid,
-                                   screen: MockScreen.error,
-                                   titleKey: "Something went wrong",
-                                   error: MockError())
+        let view = ErrorScreenView(
+            id: uuid,
+            screen: MockScreen.error,
+            titleKey: "Something went wrong",
+            error: MockError()
+        )
         
         XCTAssertEqual(view.title, "something went wrong")
-        XCTAssertEqual(view.parameters, [
-            "screen_id": uuid,
-            "hash": "83766358f64858b51afb745bbdde91bb",
-            "reason": "server",
-            "endpoint": "fetchbiometrictoken",
-            "status": "429"])
+        XCTAssertEqual(
+            view.parameters,
+            [
+                "screen_id": uuid,
+                "hash": "83766358f64858b51afb745bbdde91bb",
+                "reason": "server",
+                "endpoint": "fetchbiometrictoken",
+                "status": "429",
+                "is_error": "true"
+            ]
+        )
     }
     
     func testParametersForValues() {
         let uuid = UUID().uuidString.lowercased()
-
-        let view = ErrorScreenView(id: uuid,
-                                   screen: MockScreen.error,
-                                   titleKey: "Something went wrong",
-                                   reason: "network",
-                                   endpoint: "appInfo",
-                                   statusCode: "401",
-                                   hash: "83766358f64858b51afb745bbdde91bb"
+        
+        let view = ErrorScreenView(
+            id: uuid,
+            screen: MockScreen.error,
+            titleKey: "Something went wrong",
+            reason: "network",
+            endpoint: "appInfo",
+            statusCode: "401",
+            hash: "83766358f64858b51afb745bbdde91bb",
         )
         
-        XCTAssertEqual(view.parameters, [
-            "screen_id": uuid,
-            "reason": "network",
-            "endpoint": "appinfo",
-            "status": "401",
-            "hash": "83766358f64858b51afb745bbdde91bb"
-        ])
+        XCTAssertEqual(
+            view.parameters,
+            [
+                "screen_id": uuid,
+                "reason": "network",
+                "endpoint": "appinfo",
+                "status": "401",
+                "hash": "83766358f64858b51afb745bbdde91bb",
+                "is_error": "true"
+            ]
+        )
     }
 }

--- a/Tests/GDSAnalyticsTests/Screens/ErrorScreenViewTests.swift
+++ b/Tests/GDSAnalyticsTests/Screens/ErrorScreenViewTests.swift
@@ -66,7 +66,7 @@ final class ErrorScreenViewTests: XCTestCase {
             reason: "network",
             endpoint: "appInfo",
             statusCode: "401",
-            hash: "83766358f64858b51afb745bbdde91bb",
+            hash: "83766358f64858b51afb745bbdde91bb"
         )
         
         XCTAssertEqual(

--- a/Tests/GDSAnalyticsTests/Screens/ScreenViewTests.swift
+++ b/Tests/GDSAnalyticsTests/Screens/ScreenViewTests.swift
@@ -17,18 +17,26 @@ final class ScreenViewTests: XCTestCase {
                               screen: MockScreen.welcome,
                               titleKey: "welcome to this app")
         
-        XCTAssertEqual(view.parameters, [
-            "screen_id": uuid
-        ])
+        XCTAssertEqual(
+            view.parameters, [
+                "screen_id": uuid,
+                "is_error": "false"
+            ]
+        )
     }
     
     
     func testParameterTruncation() {
-        let view = ScreenView(screen: MockScreen.welcome,
-                              titleKey: "Welcome to this app with a really really really really really really really really really really long name")
+        let view = ScreenView(
+            screen: MockScreen.welcome,
+            titleKey: "Welcome to this app with a really really really really really really really really really really long name"
+        )
 
         XCTAssertEqual(view.title, "welcome to this app with a really really really really really really really really really really lon")
         
-        XCTAssertEqual(view.parameters, [:])
+        XCTAssertEqual(
+            view.parameters,
+            ["is_error": "false"]
+        )
     }
 }


### PR DESCRIPTION
# Adding of `is_error` parameter to screen view events

All screen view events will return a parameter `is_error`.
`ErrorScreenView` events will return `"is_error": "true"`
`ScreenView` (not error) events will return `"is_error": "false"`


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
