### PR TITLE
feat: dcmaw 14345 add default saved doc type

### DIFF
--- a/Sources/GAnalytics/GAnalytics.swift
+++ b/Sources/GAnalytics/GAnalytics.swift
@@ -60,7 +60,7 @@ public struct GAnalytics {
     
     /// Merging `parameters` dictionary parameter with `additionalParameters` property
     private func mergeAdditionalParameters(_ parameters: [String: Any]) -> [String: Any] {
-        additionalParameters.merging(parameters) { lhs, rhs in
+        additionalParameters.merging(parameters) { lhs, _ in
             lhs
         }
     }

--- a/Sources/GAnalytics/GAnalytics.swift
+++ b/Sources/GAnalytics/GAnalytics.swift
@@ -60,7 +60,9 @@ public struct GAnalytics {
     
     /// Merging `parameters` dictionary parameter with `additionalParameters` property
     private func mergeAdditionalParameters(_ parameters: [String: Any]) -> [String: Any] {
-        additionalParameters.merging(parameters) { $1 }
+        additionalParameters.merging(parameters) { lhs, rhs in
+            lhs
+        }
     }
 }
 
@@ -69,10 +71,7 @@ extension GAnalytics: AnalyticsService {
         _ additionalParameters: [String: Any]
     ) -> Self {
         var newCopy = self
-        newCopy.additionalParameters = self.additionalParameters
-            .merging(additionalParameters) { lhs, _ in
-                lhs
-            }
+        newCopy.additionalParameters = self.mergeAdditionalParameters(additionalParameters)
         return newCopy
     }
     

--- a/Sources/GAnalytics/GAnalyticsV2.swift
+++ b/Sources/GAnalytics/GAnalyticsV2.swift
@@ -60,7 +60,9 @@ public struct GAnalyticsV2 {
     
     /// Merging `parameters` dictionary parameter with `additionalParameters` property
     private func mergeAdditionalParameters(_ parameters: [String: Any]) -> [String: Any] {
-        additionalParameters.merging(parameters) { $1 }
+        additionalParameters.merging(parameters) { lhs, _ in
+            lhs
+        }
     }
 }
 
@@ -69,10 +71,7 @@ extension GAnalyticsV2: AnalyticsServiceV2 {
         _ additionalParameters: [String: Any]
     ) -> Self {
         var newCopy = self
-        newCopy.additionalParameters = self.additionalParameters
-            .merging(additionalParameters) { lhs, _ in
-                lhs
-            }
+        newCopy.additionalParameters = self.mergeAdditionalParameters(additionalParameters)
         return newCopy
     }
     

--- a/Sources/GDSAnalytics/Screens/ErrorScreenView.swift
+++ b/Sources/GDSAnalytics/Screens/ErrorScreenView.swift
@@ -8,6 +8,7 @@ public struct ErrorScreenView<Screen: ScreenType>: ScreenViewProtocol, LoggableE
     public let endpoint: String?
     public let statusCode: String?
     public let hash: String?
+    public let savedDocType: String
     
     public var parameters: [String: String] {
         [
@@ -16,19 +17,23 @@ public struct ErrorScreenView<Screen: ScreenType>: ScreenViewProtocol, LoggableE
             ScreenParameter.endpoint.rawValue: endpoint,
             ScreenParameter.hash.rawValue: hash,
             ScreenParameter.status.rawValue: statusCode,
+            ScreenParameter.savedDocType.rawValue: savedDocType,
             ScreenParameter.isError.rawValue: "true"
         ]
         .compactMapValues(\.?.formattedAsParameter)
     }
     
-    public init(id: String? = nil,
-                screen: Screen,
-                titleKey: String,
-                reason: String? = nil,
-                endpoint: String? = nil,
-                statusCode: String? = nil,
-                hash: String? = nil,
-                bundle: Bundle = .main) {
+    public init(
+        id: String? = nil,
+        screen: Screen,
+        titleKey: String,
+        reason: String? = nil,
+        endpoint: String? = nil,
+        statusCode: String? = nil,
+        hash: String? = nil,
+        bundle: Bundle = .main,
+        savedDocType: String = "undefined"
+    ) {
         self.screen = screen
         self.title = titleKey.englishString(bundle: bundle).formattedAsParameter
         self.id = id
@@ -36,15 +41,20 @@ public struct ErrorScreenView<Screen: ScreenType>: ScreenViewProtocol, LoggableE
         self.endpoint = endpoint
         self.statusCode = statusCode
         self.hash = hash
+        self.savedDocType = savedDocType
     }
     
-    public init(id: String? = nil,
-                screen: Screen,
-                titleKey: String,
-                error: LoggableError,
-                bundle: Bundle = .main) {
+    public init(
+        id: String? = nil,
+        screen: Screen,
+        titleKey: String,
+        error: LoggableError,
+        bundle: Bundle = .main,
+        savedDocType: String = "undefined"
+    ) {
         self.id = id
         self.screen = screen
+        self.savedDocType = savedDocType
         title = titleKey.englishString(bundle: bundle).formattedAsParameter
         reason = error.reason
         endpoint = error.endpoint

--- a/Sources/GDSAnalytics/Screens/ScreenParameter.swift
+++ b/Sources/GDSAnalytics/Screens/ScreenParameter.swift
@@ -5,4 +5,5 @@ public enum ScreenParameter: String {
     case hash
     case id = "screen_id"
     case isError = "is_error"
+    case savedDocType = "saved_doc_type"
 }

--- a/Sources/GDSAnalytics/Screens/ScreenView.swift
+++ b/Sources/GDSAnalytics/Screens/ScreenView.swift
@@ -5,6 +5,7 @@ public protocol ScreenViewProtocol: Equatable {
     var id: String? { get }
     var screen: Screen { get }
     var title: String { get }
+    var savedDocType: String { get }
     var parameters: [String: String] { get }
 }
 
@@ -12,22 +13,28 @@ public struct ScreenView<Screen: ScreenType>: ScreenViewProtocol {
     public let id: String?
     public let screen: Screen
     public let title: String
+    public let savedDocType: String
     
     public var parameters: [String: String] {
         [
             ScreenParameter.id.rawValue: id,
+            ScreenParameter.savedDocType.rawValue: savedDocType,
             ScreenParameter.isError.rawValue: "false"
         ].compactMapValues(\.?.formattedAsParameter)
     }
     
-    public init(id: String? = nil,
-                screen: Screen,
-                titleKey: String,
-                variableKeys: [String] = [],
-                bundle: Bundle = .main) {
+    public init(
+        id: String? = nil,
+        screen: Screen,
+        titleKey: String,
+        variableKeys: [String] = [],
+        savedDocType: String = "undefined",
+        bundle: Bundle = .main
+    ) {
         self.id = id
         self.screen = screen
         self.title = titleKey.englishString(variableKeys, bundle: bundle).formattedAsParameter
+        self.savedDocType = savedDocType
     }
 }
 

--- a/Tests/GAnalyticsTests/GAnalyticsTests.swift
+++ b/Tests/GAnalyticsTests/GAnalyticsTests.swift
@@ -196,6 +196,35 @@ extension GAnalyticsTests {
         )
     }
     
+    func testTrackScreenAdditionalParametersPrecedence() {
+        sut.additionalParameters = [
+            "journey": "id_verification"
+        ]
+        
+        sut.trackScreen(
+            TestScreen.welcome,
+            parameters: [
+                "additional_parameter": "testing",
+                "journey": "something_else"
+            ]
+        )
+        
+        XCTAssertEqual(
+            analyticsLogger.events,
+            [
+                .init(
+                    name: "screen_view",
+                    parameters: [
+                        "screen_name": "WELCOME_SCREEN",
+                        "screen_class": "WELCOME_SCREEN",
+                        "additional_parameter": "testing",
+                        "journey": "id_verification"
+                    ]
+                )
+            ]
+        )
+    }
+    
     func testTrackScreenV2() {
         struct TestScreenV2: LoggableScreenV2 {
             let name: String = "Welcome to GOV.UK One Login"

--- a/Tests/GAnalyticsTests/GAnalyticsV2Tests.swift
+++ b/Tests/GAnalyticsTests/GAnalyticsV2Tests.swift
@@ -197,6 +197,35 @@ extension GAnalyticsTestsV2 {
         )
     }
     
+    func testTrackScreenAdditionalParametersPrecedence() {
+        sut.additionalParameters = [
+            "journey": "id_verification"
+        ]
+        
+        sut.trackScreen(
+            TestScreen.welcome,
+            parameters: [
+                "additional_parameter": "testing",
+                "journey": "something_else"
+            ]
+        )
+        
+        XCTAssertEqual(
+            analyticsLogger.events,
+            [
+                .init(
+                    name: "screen_view",
+                    parameters: [
+                        "screen_name": "WELCOME_SCREEN",
+                        "screen_class": "WELCOME_SCREEN",
+                        "additional_parameter": "testing",
+                        "journey": "id_verification"
+                    ]
+                )
+            ]
+        )
+    }
+    
     func testTrackScreenV2() {
         struct TestScreenV2: LoggableScreenV2 {
             let name: String = "Welcome to GOV.UK One Login"

--- a/Tests/GDSAnalyticsTests/Screens/ErrorScreenViewTests.swift
+++ b/Tests/GDSAnalyticsTests/Screens/ErrorScreenViewTests.swift
@@ -21,7 +21,8 @@ final class ErrorScreenViewTests: XCTestCase {
             view.parameters,
             [
                 "screen_id": uuid,
-                "is_error": "true"
+                "is_error": "true",
+                "saved_doc_type": "undefined"
             ]
         )
     }
@@ -51,7 +52,8 @@ final class ErrorScreenViewTests: XCTestCase {
                 "reason": "server",
                 "endpoint": "fetchbiometrictoken",
                 "status": "429",
-                "is_error": "true"
+                "is_error": "true",
+                "saved_doc_type": "undefined"
             ]
         )
     }
@@ -77,7 +79,8 @@ final class ErrorScreenViewTests: XCTestCase {
                 "endpoint": "appinfo",
                 "status": "401",
                 "hash": "83766358f64858b51afb745bbdde91bb",
-                "is_error": "true"
+                "is_error": "true",
+                "saved_doc_type": "undefined"
             ]
         )
     }

--- a/Tests/GDSAnalyticsTests/Screens/ScreenViewTests.swift
+++ b/Tests/GDSAnalyticsTests/Screens/ScreenViewTests.swift
@@ -20,7 +20,8 @@ final class ScreenViewTests: XCTestCase {
         XCTAssertEqual(
             view.parameters, [
                 "screen_id": uuid,
-                "is_error": "false"
+                "is_error": "false",
+                "saved_doc_type": "undefined"
             ]
         )
     }
@@ -36,7 +37,10 @@ final class ScreenViewTests: XCTestCase {
         
         XCTAssertEqual(
             view.parameters,
-            ["is_error": "false"]
+            [
+                "is_error": "false",
+                "saved_doc_type": "undefined"
+            ]
         )
     }
     


### PR DESCRIPTION
# Adjust parameter merging precedence and add default `"saved_doc_type"` parameter for screen view events

This is required by the analytics team.

To make this useable, precedence on merging parameters from events is adjusted to match the precedence when merging params creating new analytics services.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
